### PR TITLE
Add a Jenkinsfile to build with Docker and the pbuilder steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# NMOS Web Router Changelog
+
+## 1.0.0
+- Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # NMOS Web Router Changelog
 
+## 1.0.1
+- Build using Docker/Jenkinsfile pattern used elsewhere.
+
 ## 1.0.0
 - Initial release

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,8 @@ WORKDIR /usr/src/app
 
 COPY . /usr/src/app
 
-RUN yarn config set color false
-RUN yarn config set proxy http://www-cache.rd.bbc.co.uk:8080
-RUN yarn config set https-proxy http://www-cache.rd.bbc.co.uk:8080
+RUN yarn config set color false && yarn config set proxy http://www-cache.rd.bbc.co.uk:8080 && \
+    yarn config set https-proxy http://www-cache.rd.bbc.co.uk:8080
 
 RUN yarn install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,5 @@ RUN yarn config set proxy http://www-cache.rd.bbc.co.uk:8080
 RUN yarn config set https-proxy http://www-cache.rd.bbc.co.uk:8080
 
 RUN yarn install
-RUN yarn run ci
 
 EXPOSE 4000 3000 6589 6590 6591 12345

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
                 }
             }
             steps {
-                // bbcNpmRunScript("ci")
+                bbcNpmRunScript("ci")
                 bbcNpmRunScript("build")
                 stash(name: "built-site", includes: "build/**")
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,8 @@ pipeline {
                 bbcGithubNotify(context: "deb/sourceBuild", status: "PENDING")
 
                 unstash(name: "built-site")
-                sh 'debuild -uc -us -S'
+                sh "scripts/make_dsc.sh"
+
                 bbcPrepareDsc()
                 stash(name: "deb_dist", includes: "deb_dist/*")
                 script {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,129 @@
+@Library("rd-apmm-groovy-ci-library@v1.x") _
+
+/*
+- Starts up a Docker container, runs the lint, test and build targets in package.json
+- Stashes resulting build artifacts
+- Switches back to one of the bare-metal Agents and unstashes build artifacts
+- Builds Debian packages, and uploads to the repos
+- Reports status to GitHub
+*/
+pipeline {
+    agent {
+        label "ubuntu&&apmm-slave"
+    }
+    options {
+        ansiColor('xterm') // Add support for coloured output
+        buildDiscarder(logRotator(numToKeepStr: '10')) // Discard old builds
+    }
+    parameters {
+        booleanParam(name: "FORCE_DEBUPLOAD", defaultValue: false, description: "Force Debian package upload")
+    }
+    environment {
+        http_proxy = "http://www-cache.rd.bbc.co.uk:8080"
+        https_proxy = "http://www-cache.rd.bbc.co.uk:8080"
+        HOME="/var/tmp/home-for-npm"  // Override the npm cache directory to avoid: EACCES: permission denied, mkdir '/.npm'
+        yarn_cache_folder="/var/tmp/yarn-cache" // give an explicit location for the cache inside the jenkins workspace
+    }
+    stages {
+        stage("Clean Environment") {
+            steps {
+                sh 'git clean -fdx'
+            }
+        }
+        stage("Lint, test and build in Docker container") {
+            agent {
+                dockerfile {
+                    // Mount the Jenkins agent's certificates
+                    args "-v /etc/pki/tls/:/etc/pki/tls/"
+                }
+            }
+            steps {
+                // bbcNpmRunScript("ci")
+                bbcNpmRunScript("build")
+                stash(name: "built-site", includes: "build/**")
+            }
+        }
+        stage ("Debian Source Build") {
+            steps {
+                script {
+                    env.debSourceBuild_result = "FAILURE"
+                }
+                bbcGithubNotify(context: "deb/sourceBuild", status: "PENDING")
+
+                unstash(name: "built-site")
+                sh 'debuild -uc -us -S'
+                bbcPrepareDsc()
+                stash(name: "deb_dist", includes: "deb_dist/*")
+                script {
+                    env.debSourceBuild_result = "SUCCESS" // This will only run if the steps above succeeded
+                }
+            }
+            post {
+                always {
+                    bbcGithubNotify(context: "deb/sourceBuild", status: env.debSourceBuild_result)
+                }
+            }
+        }
+        stage ("Build Packages") {
+            parallel{
+                stage ("Build Deb with pbuilder") {
+                    steps {
+                        script {
+                            env.pbuilder_result = "FAILURE"
+                        }
+                        bbcGithubNotify(context: "deb/packageBuild", status: "PENDING")
+                        // Build for all supported platforms and extract results into workspace
+                        bbcParallelPbuild(
+                            stashname: "deb_dist",
+                            dists: bbcGetSupportedUbuntuVersions(),
+                            arch: "amd64")
+                        script {
+                            env.pbuilder_result = "SUCCESS" // This will only run if the steps above succeeded
+                        }
+                    }
+                    post {
+                        success {
+                            archiveArtifacts artifacts: "_result/**"
+                        }
+                        always {
+                            bbcGithubNotify(context: "deb/packageBuild", status: env.pbuilder_result)
+                        }
+                    }
+                }
+            }
+        }
+        stage ("Upload Debian Package") {
+            // Duplicates the when clause of each upload so blue ocean can nicely display when stage skipped
+            when {
+                anyOf {
+                    expression { return params.FORCE_DEBUPLOAD }
+                    expression {
+                        bbcShouldUploadArtifacts(branches: ["master"])
+                    }
+                }
+            }
+            steps {
+                script {
+                    env.debUpload_result = "FAILURE"
+                }
+                bbcGithubNotify(context: "deb/upload", status: "PENDING")
+                script {
+                    for (def dist in bbcGetSupportedUbuntuVersions()) {
+                        bbcDebUpload(sourceFiles: "_result/${dist}-amd64/*",
+                                        removePrefix: "_result/${dist}-amd64",
+                                        dist: "${dist}",
+                                        apt_repo: "ap/python")
+                    }
+                }
+                script {
+                    env.debUpload_result = "SUCCESS" // This will only run if the steps above succeeded
+                }
+            }
+            post {
+                always {
+                    bbcGithubNotify(context: "deb/upload", status: env.debUpload_result)
+                }
+            }
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,9 @@ pipeline {
         ansiColor('xterm') // Add support for coloured output
         buildDiscarder(logRotator(numToKeepStr: '10')) // Discard old builds
     }
+    triggers {
+        cron(env.BRANCH_NAME == 'master' ? 'H H(0-8) * * 6' : '') // Build master some time every Saturday morning
+    }
     parameters {
         booleanParam(name: "FORCE_DEBUPLOAD", defaultValue: false, description: "Force Debian package upload")
     }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ips-web (1.0.1) xenial; urgency=medium
+
+  * Build using Docker/Jenkinsfile pattern used elsewhere 
+
+ -- Sam Mesterton-Gibbons <sam.mesterton-gibbons@bbc.co.uk>  Mon, 01 Apr 2019 16:08:54 +0100
+
 ips-web (1.0.0) natty; urgency=low
 
   * Initial relase.

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: ips-web
 Priority: optional
 Section: web
 Maintainer: Luke Preston <luke.preston@bbc.co.uk>
-Standards-Version: 3.9.3
+Standards-Version: 3.9.7
 Build-Depends: debhelper (>= 9), apache2-dev
 
 Package: ips-web

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,0 +1,21 @@
+Format: http://dep.debian.net/deps/dep5
+Upstream-Name: nmos-web-router
+Source: https://github.com/bbc/nmos-web-router
+
+Files: *
+Copyright: 2015-2019 BBC Research & Development
+License: Apache 2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ .
+     http://www.apache.org/licenses/LICENSE-2.0
+ .
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ .
+ On Debian systems, the complete text of the Apache License 2.0 can
+ be found in "/usr/share/common-licenses/Apache-2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ips-web",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "BBC",
   "private": true,
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ips-web",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "author": "BBC",
   "private": true,
   "devDependencies": {

--- a/scripts/make_dsc.sh
+++ b/scripts/make_dsc.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Build a .dsc file and copy it into deb_dist/
+
+rm -Rf deb_dist
+mkdir -p deb_dist/ips-web/
+
+# Copy built JS/HTML and debian metadata into place to build packages
+cp -R build deb_dist/ips-web/
+cp -R debian deb_dist/ips-web/
+
+# Run the actual build
+(cd deb_dist/ips-web && debuild -uc -us -S)


### PR DESCRIPTION
- Adds a Jenkinsfile to build Debian packages by running the `yarn run build` step in a Docker container, then the rest of the Debian build process on the bare-metal agent (with pbuilder)
- Configures Jenkins to rebuild master on Saturday mornings
- Moves the CI target run from the Dockerfile up to the Jenkinsfile, and optimizes the Dockerfile a bit
- Updates Debian packaging standards version and adds a copyright file for the Apache 2 licence.
- Adds a CHANGELOG.md file
- Harmonizes package.json and Debian versions.
- Bumps version to 1.0.1