### PR TITLE
Allow External OAuth Client Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS Web Router Changelog
 
+## 1.1.2
+- Add external config file to edit OAuth2 client credentials
+
 ## 1.1.1
 - Fix bug in handling of hostnames/IPs for HTTPS
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ips-web (1.1.2) xenial; urgency=medium
+
+  * Add external config file to edit OAuth2 client credentials
+
+ -- Danny Meloy <danny.meloy@bbc.co.uk>  Mon  1 Jul 15:05:19 BST 2019
+
 ips-web (1.1.1) xenial; urgency=medium
 
   * Fix bug in handling of HTTPS and hostnames

--- a/debian/install
+++ b/debian/install
@@ -1,4 +1,4 @@
 build/static	usr/share/ips-web
 build/index.html	usr/share/ips-web
 build/favicon.ico	usr/share/ips-web
-build/auth_config.json usr/share/ips-web
+build/auth_config.js usr/share/ips-web

--- a/debian/install
+++ b/debian/install
@@ -1,3 +1,4 @@
 build/static	usr/share/ips-web
 build/index.html	usr/share/ips-web
 build/favicon.ico	usr/share/ips-web
+build/auth_config.json usr/share/ips-web

--- a/public/auth_config.js
+++ b/public/auth_config.js
@@ -1,4 +1,4 @@
-{
+var authConfig = {
 	"client_id": "test",
 	"client_secret": "test_secret"
 }

--- a/public/auth_config.json
+++ b/public/auth_config.json
@@ -1,0 +1,4 @@
+{
+	"client_id": "test",
+	"client_secret": "test_secret"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>IP Studio Web</title>
     <link rel="shortcut icon" href="/ips-web/favicon.ico">
+    <script type="text/javascript" src="auth_config.js"></script>
   </head>
   <body>
-    <script type="text/javascript" language="javascript" src="auth_config.json"></script>
     <div id="root"></div>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,7 @@
     <link rel="shortcut icon" href="/ips-web/favicon.ico">
   </head>
   <body>
+    <script type="text/javascript" language="javascript" src="auth_config.json"></script>
     <div id="root"></div>
   </body>
 </html>

--- a/src/web-router/components/index.jsx
+++ b/src/web-router/components/index.jsx
@@ -9,7 +9,6 @@ import SignIn from './security/signin-component'
 let WebRouter = ({data, view, actions}) => {
   let location = view.location || '/choose'
   return <div style={{ width: '100%' }}>
-    <div className='signIn-background' />
     <div className='sign-in'>
       <SignIn view={view} actions={actions} />
     </div>

--- a/src/web-router/components/web-router.css
+++ b/src/web-router/components/web-router.css
@@ -36,8 +36,9 @@ the file from top to bottom styles the web router from top to bottom */
 
 .sign-in {
   position: absolute;
-  left: 42.5%;
-  width: 15%;
+  left: 0;
+  right: 0;
+  width: 250px;
   margin: auto;
   top: 12px;
   z-index: 1;

--- a/src/web-router/dispatchers/security/constants.js
+++ b/src/web-router/dispatchers/security/constants.js
@@ -1,4 +1,4 @@
 export const TOKEN_KEY = 'accessToken'
-export const CLIENT_ID = '0oey7t5tuKpkPeio7zerDjj3'
-export const CLIENT_SECRET = 'pyM4TNrZsY1et2HKmmUzYVijGIBpMqZOkEIbLa7gLDi8OtR4'
+export const CLIENT_ID = '4zk5xjDWla3S7YVEEIOqTjQI'
+export const CLIENT_SECRET = 'V8dEXpcZszxRlPrACSZhHD1M1UTdsgIJQuft2r1x5lvuBhIi'
 export const AUTH_API_VERSION = 'v1.0'

--- a/src/web-router/dispatchers/security/signin-request.js
+++ b/src/web-router/dispatchers/security/signin-request.js
@@ -3,6 +3,9 @@ const qs = require('qs')
 import { CLIENT_ID, CLIENT_SECRET, AUTH_API_VERSION } from './constants'
 import { getServiceUrl, queryPriority } from '../../../init-nmos'
 
+const clientId = window.authConfig ? window.authConfig.client_id : CLIENT_ID
+const clientSecret = window.authConfig ? window.authConfig.client_secret : CLIENT_SECRET
+
 export default (username, password) => {
   let scope = 'is05'
   let data = {
@@ -19,8 +22,8 @@ export default (username, password) => {
         method: 'post',
         data: qs.stringify(data),
         auth: {
-          username: CLIENT_ID,
-          password: CLIENT_SECRET
+          username: clientId,
+          password: clientSecret
         }
       })
     })


### PR DESCRIPTION
Add ability to pull in external .js file containing client credentials (primarily for testing purposes when using the installed bundle)