### PR TITLE
add ability to filter routables with key/value pair

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ips-web (1.1.3) xenial; urgency=medium
+
+  * Add ability to filter routables using key/value pair
+
+ -- Danny Meloy <danny.meloy@bbc.co.uk>  Tue  2 Jul 15:22:14 BST 2019
+
 ips-web (1.1.2) xenial; urgency=medium
 
   * Add external config file to edit OAuth2 client credentials

--- a/src/web-router/reducers/initialise/index.js
+++ b/src/web-router/reducers/initialise/index.js
@@ -32,6 +32,7 @@ export default (state, action, merge) => {
   routables.insert.senders(data.senders)
   routables.insert.flows(data.flows)
   routables.filter(state.view.choose.term)
+  routables.filter({'transport': 'rtp'})
 
   if (state.view.useSessionStorage) {
     routables.check.senders('saved')

--- a/src/web-router/reducers/update-reducer.js
+++ b/src/web-router/reducers/update-reducer.js
@@ -24,6 +24,7 @@ export default (state, action, merge) => {
 
   routables.update[action.name](action.update[action.name])
   routables.filter(state.view.choose.term)
+  routables.filter({'transport': 'rtp'})
   if (state.view.routingMode === 'manual') routables.checkFor('removed')
 
   let updatedView = routables.view()

--- a/src/web-router/routables/filter/index.js
+++ b/src/web-router/routables/filter/index.js
@@ -22,6 +22,7 @@ Filter is used to filter routables out of the 'Choose' view according to
 import cloneRoutables from '../common/clone-routables'
 import View from '../view'
 import mapFuzzymatch from './map-fuzzymatch'
+import mapTransport from './map-transport'
 
 export default (data) => {
   data = cloneRoutables(data)
@@ -29,8 +30,13 @@ export default (data) => {
     let senders = data.senders
     let receivers = data.receivers
 
-    mapFuzzymatch(term, senders)
-    mapFuzzymatch(term, receivers)
+    if (typeof term === 'string') {
+      mapFuzzymatch(term, senders)
+      mapFuzzymatch(term, receivers)
+    } else {
+      mapTransport(term, senders)
+      mapTransport(term, receivers)
+    }
 
     return View(data)
   }

--- a/src/web-router/routables/filter/index.js
+++ b/src/web-router/routables/filter/index.js
@@ -22,7 +22,7 @@ Filter is used to filter routables out of the 'Choose' view according to
 import cloneRoutables from '../common/clone-routables'
 import View from '../view'
 import mapFuzzymatch from './map-fuzzymatch'
-import mapTransport from './map-transport'
+import mapFilter from './map-filter'
 
 export default (data) => {
   data = cloneRoutables(data)
@@ -34,8 +34,8 @@ export default (data) => {
       mapFuzzymatch(term, senders)
       mapFuzzymatch(term, receivers)
     } else {
-      mapTransport(term, senders)
-      mapTransport(term, receivers)
+      mapFilter(term, senders)
+      mapFilter(term, receivers)
     }
 
     return View(data)

--- a/src/web-router/routables/filter/map-filter.js
+++ b/src/web-router/routables/filter/map-filter.js
@@ -21,7 +21,7 @@ export default (term, routables) => {
   routables.forEach(routable => {
     let dataKey = Object.keys(term)[0]
     let searchTerm = Object.values(term)[0]
-    let transportMatch = (routable[dataKey].includes(searchTerm))
+    let transportMatch = routable[dataKey].includes(searchTerm)
 
     let routableMapState = mapState(routable)
     if (transportMatch) routableMapState.fuzzymatch()

--- a/src/web-router/routables/filter/map-filter.js
+++ b/src/web-router/routables/filter/map-filter.js
@@ -21,10 +21,10 @@ export default (term, routables) => {
   routables.forEach(routable => {
     let dataKey = Object.keys(term)[0]
     let searchTerm = Object.values(term)[0]
-    let transportMatch = routable[dataKey].includes(searchTerm)
+    let filterMatch = routable[dataKey].includes(searchTerm)
 
     let routableMapState = mapState(routable)
-    if (transportMatch) routableMapState.fuzzymatch()
+    if (filterMatch) routableMapState.fuzzymatch()
     else routableMapState.fuzzymissmatch()
     routable.state = routableMapState.state()
     routable.stateString = stateToString(routable.state)

--- a/src/web-router/routables/filter/map-transport.js
+++ b/src/web-router/routables/filter/map-transport.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2019 British Broadcasting Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import mapState from '../common/map-state'
+import stateToString from '../common/state-to-string'
+
+export default (term, routables) => {
+  routables.forEach(routable => {
+    let dataKey = Object.keys(term)[0]
+    let searchTerm = Object.values(term)[0]
+    let transportMatch = (routable[dataKey].includes(searchTerm))
+
+    let routableMapState = mapState(routable)
+    if (transportMatch) routableMapState.fuzzymatch()
+    else routableMapState.fuzzymissmatch()
+    routable.state = routableMapState.state()
+    routable.stateString = stateToString(routable.state)
+  })
+}


### PR DESCRIPTION
Didn't want to mangle this well-thought-out code anymore than I already have, so I've just tweeked the existing routables `filter` function to accept an object that is then used to filter the data within the `routables` objects. 