### PR TITLE
Fix search on WebSocket update and windowing or browser zoom

### DIFF
--- a/src/web-router/components/scroll-windowing/debounce.js
+++ b/src/web-router/components/scroll-windowing/debounce.js
@@ -1,0 +1,25 @@
+/**
+ * Delay a function call by an amount of time
+ * since the last call attempt.
+ *
+ * @param {Number} delay wait before function is called
+ * @param {Function} fn function to call after delay
+ */
+export default (delay, fn) => {
+  let timerId
+
+  return (...args) => {
+    if (timerId) {
+      window.clearTimeout(timerId)
+    }
+
+    /**
+     * Call the function after a delay. This will be
+     * cleared and restarted debounce is called again.
+     */
+    timerId = window.setTimeout(() => {
+      fn(...args)
+      timerId = null
+    }, delay)
+  }
+}

--- a/src/web-router/components/scroll-windowing/scroll-windowing.jsx
+++ b/src/web-router/components/scroll-windowing/scroll-windowing.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react'
 import { cancelTimeout, requestTimeout } from './timeout'
+import debounce from './debounce'
 import callAll from './call-all'
 
 /**
@@ -45,6 +46,26 @@ class ScrollWindowing extends React.Component {
     this.getScrollProps = this.getScrollProps.bind(this)
     this.onScroll = this.onScroll.bind(this)
     this.setRef = this.setRef.bind(this)
+
+    /**
+     * Resizing is quite intensive, so it has been debounced to
+     * only update once the user has finished or paused resizing.
+     */
+    this.onResize = debounce(150, this.onResize.bind(this))
+  }
+
+  /**
+   * Listen for window resizing
+   */
+  componentDidMount () {
+    window.addEventListener('resize', this.onResize)
+  }
+
+  /**
+   * Unbind any event listener
+   */
+  componentWillUnmount () {
+    window.removeEventListener('resize', this.onResize)
   }
 
   /**
@@ -64,6 +85,16 @@ class ScrollWindowing extends React.Component {
          */
         this.onScroll({ currentTarget: this.ref }, true)
       }
+    }
+  }
+
+  /**
+   * Trigger the `onScroll` event on resize/zoom to update
+   * the viewport dimensions and visible indexes.
+   */
+  onResize () {
+    if (this.ref && this.initialsed) {
+      this.onScroll({ currentTarget: this.ref }, true)
     }
   }
 

--- a/src/web-router/constants/filterMethods.js
+++ b/src/web-router/constants/filterMethods.js
@@ -1,0 +1,2 @@
+export const FUZZY_SEARCH = 'FUZZY_SEARCH'
+export const INCLUDES = 'INCLUDES'

--- a/src/web-router/constants/filterOperators.js
+++ b/src/web-router/constants/filterOperators.js
@@ -1,0 +1,2 @@
+export const AND = 'AND'
+export const OR = 'OR'

--- a/src/web-router/reducers/initialise/index.js
+++ b/src/web-router/reducers/initialise/index.js
@@ -18,6 +18,8 @@ import loading from './loading'
 import Routables from '../../routables'
 import allVisibleState from './all-visible-state'
 import restoreChanges from './restore-changes'
+import { AND, OR } from '../../constants/filterOperators'
+import { FUZZY_SEARCH, INCLUDES } from '../../constants/filterMethods'
 
 export default (state, action, merge) => {
   let initialised = action.receivers || action.senders || action.flows
@@ -31,8 +33,22 @@ export default (state, action, merge) => {
   routables.insert.receivers(data.receivers)
   routables.insert.senders(data.senders)
   routables.insert.flows(data.flows)
-  routables.filter(state.view.choose.term)
-  routables.filter({'transport': 'rtp'})
+  // Filter by the current search term and transport type
+  routables.filter({
+    operator: AND,
+    terms: [
+      {
+        props: ['label', 'id'],
+        term: state.view.choose.term,
+        method: FUZZY_SEARCH,
+        operator: OR
+      }, {
+        props: ['transport'],
+        term: 'rtp',
+        method: INCLUDES
+      }
+    ]
+  })
 
   if (state.view.useSessionStorage) {
     routables.check.senders('saved')

--- a/src/web-router/reducers/update-reducer.js
+++ b/src/web-router/reducers/update-reducer.js
@@ -16,6 +16,8 @@
 
 import Routables from '../routables'
 import allVisible from './choose/all-visible'
+import { AND, OR } from '../constants/filterOperators'
+import { FUZZY_SEARCH, INCLUDES } from '../constants/filterMethods'
 
 export default (state, action, merge) => {
   let routables = Routables(state.view)
@@ -23,8 +25,22 @@ export default (state, action, merge) => {
   if (action.name === 'view') return merge({view})
 
   routables.update[action.name](action.update[action.name])
-  routables.filter(state.view.choose.term)
-  routables.filter({'transport': 'rtp'})
+  // Filter by the current search term and transport type
+  routables.filter({
+    operator: AND,
+    terms: [
+      {
+        props: ['label', 'id'],
+        term: state.view.choose.term,
+        method: FUZZY_SEARCH,
+        operator: OR
+      }, {
+        props: ['transport'],
+        term: 'rtp',
+        method: INCLUDES
+      }
+    ]
+  })
   if (state.view.routingMode === 'manual') routables.checkFor('removed')
 
   view = routables.view()

--- a/src/web-router/routables/filter/map-filter.js
+++ b/src/web-router/routables/filter/map-filter.js
@@ -14,19 +14,98 @@
  * limitations under the License.
  */
 
+import fuzzysearch from 'fuzzysearch'
 import mapState from '../common/map-state'
 import stateToString from '../common/state-to-string'
+import { AND } from '../../constants/filterOperators'
+import { FUZZY_SEARCH, INCLUDES } from '../../constants/filterMethods'
 
-export default (term, routables) => {
+/**
+ * Applies Key-value pair or advanced filtering to routables.
+ *
+ * Expects the `conditions` property to be provided in one of the
+ * following structures:
+ *  - Basic key-value pair filtering:
+  *  { [routablePropertyName:String]: searchTermItShouldInclude:String }
+  *  e.g.
+  *  ```
+  *  {'transport': 'rtp', 'format': 'video'}
+  *  ```
+ *  - Advanced filtering:
+ *    {
+ *      operator: String, // see "constants/filterOperators.js" for options
+ *      terms: [
+ *        props: [String],
+ *        term: String|Number|Boolean,
+ *        method: String, // see "constants/filterMethods.js" for options
+ *        operator: String // see "constants/filterOperators.js" for options
+ *      ]
+ *    }
+ *    e.g.
+ *    ```
+ *    {
+ *      operator: AND,
+ *      terms: [
+ *        {
+ *          props: ['label', 'id'],
+ *          term: 'my search term',
+ *          method: FUZZY_SEARCH,
+ *          operator: OR
+ *        }, {
+ *          props: ['transport'],
+ *          term: 'rtp',
+ *          method: INCLUDES}
+ *        }
+ *      ]
+ *    }
+ *    ```
+ */
+export default ((conditions, routables) => {
+  // Extract the required advanced filtering properties
+  const { operator, terms } = conditions
+
+  // Determine filtering mode from the conditions properties
+  const advancedFiltering = operator !== undefined && terms !== undefined
+
+  // Apply filtering to all routable items
   routables.forEach(routable => {
-    let dataKey = Object.keys(term)[0]
-    let searchTerm = Object.values(term)[0]
-    let filterMatch = routable[dataKey].includes(searchTerm)
+    let allFiltersMatch = false
+
+    if (advancedFiltering) {
+      // Build the advanced conditions and filter
+      allFiltersMatch = Object.values(terms).reduce(
+        (acc, { props, method, operator: conditionOperator, term }) => {
+          // Filter by all the provided properties
+          let filterMatch = props.reduce((acc1, propKey) => {
+            let result = true
+
+            switch (method) {
+              case FUZZY_SEARCH:
+                result = fuzzysearch(term.toLowerCase(), routable[propKey].toLowerCase())
+                break
+              case INCLUDES:
+                result = routable[propKey].includes(term)
+                break
+            }
+            return conditionOperator === AND ? acc1 && result : acc1 || result
+          }, false)
+
+          return operator === AND ? acc && filterMatch : acc || filterMatch
+        },
+        true
+      )
+    } else {
+      // Filter by all key-value pairs
+      allFiltersMatch = Object.entries(conditions).reduce(
+        (acc, [key, searchTerm]) => routable[key].includes(searchTerm) && acc,
+        true
+      )
+    }
 
     let routableMapState = mapState(routable)
-    if (filterMatch) routableMapState.fuzzymatch()
+    if (allFiltersMatch) routableMapState.fuzzymatch()
     else routableMapState.fuzzymissmatch()
     routable.state = routableMapState.state()
     routable.stateString = stateToString(routable.state)
   })
-}
+})


### PR DESCRIPTION
This PR fixes both issues from https://github.com/bbc/nmos-web-router/issues/18

### Issue 1: Search results reset on WebSocket update

This issue appears to have been caused by a recent filter change (PR https://github.com/bbc/nmos-web-router/pull/13), where an additional filter was applied to the routables on initialisation and update. This caused the "search term" filtering to get reset and overwritten by the `{transport: 'rtp'}` filter.

This PR expands the `map-filter` function adding support for multiple conditions. It should now filter by both the search term and the `transport` property on initialisation and update.

### Issue 2: Restricted list items on browser zoom

On browser resize or zoom, the `scroll-windowing` component now updates the number of visible items to fill the updated viewport height.